### PR TITLE
Update Ookii.Dialogs.Wpf to v3.0.1 (.NET 5 support)

### DIFF
--- a/DnSpyCommon.props
+++ b/DnSpyCommon.props
@@ -43,7 +43,7 @@
     <MSVSIntellisenseVersion>15.5.27130</MSVSIntellisenseVersion>
     <MSVSTextVersion>15.5.27130</MSVSTextVersion>
     <NewtonsoftJsonVersion>12.0.3</NewtonsoftJsonVersion>
-    <OokiiDialogsVersion>1.0.0</OokiiDialogsVersion>
+    <OokiiDialogsWpfVersion>3.0.1</OokiiDialogsWpfVersion>
     <RoslynVersion>2.10.0</RoslynVersion>
     <SCCompositionVersion>4.6.0</SCCompositionVersion>
   </PropertyGroup>

--- a/dnSpy/dnSpy.Contracts.DnSpy/dnSpy.Contracts.DnSpy.csproj
+++ b/dnSpy/dnSpy.Contracts.DnSpy/dnSpy.Contracts.DnSpy.csproj
@@ -36,7 +36,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Ookii.Dialogs" Version="$(OokiiDialogsVersion)" />
+    <PackageReference Include="Ookii.Dialogs.Wpf" Version="$(OokiiDialogsWpfVersion)" />
     <!--TODO: This is a workaround for a bug where we get the wrong version of System.Security.Permissions.
     Microsoft.VisualStudio.Composition.NetFxAttributes and Microsoft.VisualStudio.Composition reference
     System.ComponentModel.Composition 4.5.0 which references System.Security.Permissions 4.5.0 which has

--- a/dnSpy/dnSpy/LicenseInfo/OtherLicenses.txt
+++ b/dnSpy/dnSpy/LicenseInfo/OtherLicenses.txt
@@ -102,36 +102,39 @@ Roslyn:
 NOTE: The license file is called ApacheV2.txt
 
 ***********************************************************************************
-Ookii.Dialogs:
-License agreement for Ookii.Dialogs.
+Ookii.Dialogs.Wpf:
+License agreement for Ookii.Dialogs.Wpf.
 
-Copyright © Sven Groot (Ookii.org) 2009
+BSD 3-Clause License
+
+Copyright (c) C. Augusto Proiete 2018-2020
+Copyright (c) Sven Groot         2009-2018
 All rights reserved.
 
-
-Redistribution and use in source and binary forms, with or without 
+Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
 
-1) Redistributions of source code must retain the above copyright notice, 
-   this list of conditions and the following disclaimer. 
-2) Redistributions in binary form must reproduce the above copyright notice,
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
    this list of conditions and the following disclaimer in the documentation
-   and/or other materials provided with the distribution. 
-3) Neither the name of the ORGANIZATION nor the names of its contributors
-   may be used to endorse or promote products derived from this software
-   without specific prior written permission. 
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
-LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
-THE POSSIBILITY OF SUCH DAMAGE.
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ***********************************************************************************
 Microsoft.Diagnostics.Runtime (aka clrmd):


### PR DESCRIPTION
The [Ookii.Dialogs](https://www.nuget.org/packages/Ookii.Dialogs/) NuGet package has been deprecated and replaced by [Ookii.Dialogs.Wpf](https://www.nuget.org/packages/Ookii.Dialogs.Wpf/).

- Ookii.Dialogs.Wpf v3.0 adds support for .NET Core 5 (multi-targets `net5.0-windows`, `netcoreapp3.1`, `net45`)
- Ookii.Dialogs.Wpf v2.0 adds support for .NET Core 3.1 (multi-targets `netcoreapp3.1`, `net45`)

---

Release history:
- https://github.com/augustoproiete/ookii-dialogs-wpf/releases
